### PR TITLE
.editorconfig without indent size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,6 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
If we set indent style = tab, we must not set indent size. Let the developers choose their own size! Long live tabs!